### PR TITLE
Adaptation to the raylib ConfigFlags new syntax

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -55,7 +55,7 @@
    (>= 0.6))
   conf-sdl2-gfx
   (raylib
-   (>= 1.0.0))))
+   (>= 2.0.0))))
 
 (package
  (name conf-sdl2-gfx)

--- a/gamelle.opam
+++ b/gamelle.opam
@@ -30,7 +30,7 @@ depopts: [
   "tsdl-mixer" {>= "0.6"}
   "tsdl-ttf" {>= "0.6"}
   "conf-sdl2-gfx"
-  "raylib" {>= "1.0.0"}
+  "raylib" {>= "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/raylib/gamelle_backend.ml
+++ b/raylib/gamelle_backend.ml
@@ -9,8 +9,7 @@ include Draw
 module Window = Window
 
 let run state update =
-  Raylib.set_config_flags
-    [ Raylib.ConfigFlags.Msaa_4x_hint; Raylib.ConfigFlags.Window_highdpi ];
+  Raylib.set_config_flags Raylib.ConfigFlags.(msaa_4x_hint + window_highdpi);
   Raylib.set_trace_log_level Raylib.TraceLogLevel.Warning;
   Raylib.init_window 640 640 "Gamelle";
   Raylib.set_target_fps 60;

--- a/raylib/window.ml
+++ b/raylib/window.ml
@@ -19,7 +19,7 @@ let show_cursor ~io:_ show =
   if show then Raylib.show_cursor () else Raylib.hide_cursor ()
 
 let is_fullscreen () =
-  Raylib.is_window_state Raylib.ConfigFlags.Borderless_windowed_mode
+  Raylib.is_window_state Raylib.ConfigFlags.borderless_windowed_mode
 
 let get_fullscreen ~io:_ = is_fullscreen ()
 let windowed_size = ref (640, 640)
@@ -32,10 +32,10 @@ let set_fullscreen ~io:_ fullscreen =
       Raylib.set_window_size
         (Raylib.get_monitor_width m)
         (Raylib.get_monitor_height m);
-      Raylib.set_window_state [ Raylib.ConfigFlags.Borderless_windowed_mode ]
+      Raylib.set_window_state Raylib.ConfigFlags.borderless_windowed_mode
     end
     else begin
-      Raylib.clear_window_state [ Raylib.ConfigFlags.Borderless_windowed_mode ];
+      Raylib.clear_window_state Raylib.ConfigFlags.borderless_windowed_mode;
       let w, h = !windowed_size in
       Raylib.set_window_size w h
     end


### PR DESCRIPTION
This PR updates the syntax of `Raylib.ConfigFlags` that has been changed recently. (see https://tjammer.github.io/raylib-ocaml/raylib/Raylib_core/ConfigFlags/index.html)  